### PR TITLE
trial removal of webrick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages'
 gem "kramdown", ">= 2.3.0"
-gem "webrick", "~> 1.8"
+#gem "webrick", "~> 1.8"


### PR DESCRIPTION
webrick is busted, and is apparently only actually needed locally.